### PR TITLE
fix: test case for the fallback mechanism

### DIFF
--- a/internal/auth/token_parser_test.go
+++ b/internal/auth/token_parser_test.go
@@ -59,6 +59,7 @@ func TestParseToken(t *testing.T) {
 			},
 			expectErr: false,
 			expectProps: TokenClaims{
+				ClientID:          "anon", // if there is no client_id, subject is used as client_id
 				Subject:           "anon",
 				IsActive:          false,
 				MaxPublishPerHour: config.DefaultMaxPublishPerHour,


### PR DESCRIPTION
* as a fallback in case of `client_id` is null then subject should be used as `client_id`