### PR TITLE
fix: remove duplication and reorganize guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 It supports authenticated publishing, subscribing, rate-limited usage tracking, and JWT session management.
 
-**[Detailed User Guide - Step-by-step instructions for all features](./docs/guide.md)**
+**[📖 Detailed User Guide - Complete step-by-step instructions for all features](./docs/guide.md)**
 
 ---
 
-This CLI allows you to:
+## Features
 
 - [x] Publish messages to topics
 - [x] Subscribe to real-time message streams
@@ -16,52 +16,46 @@ This CLI allows you to:
 - [x] Local rate-limiting (publish count, quota, max size)
 - [x] Usage statistics reporting
 - [x] Persist messages to local storage
-- [x] Forward messages to webhook endpoints (important: webhook take `POST` http method)
+- [x] Forward messages to webhook endpoints (POST method)
   
 ---
 
-## Installation
+## Quick Start
 
-### Quick Install (Recommended)
+### 1. Installation
 
+**Quick Install (Recommended):**
 ```sh
 curl -sSL https://raw.githubusercontent.com/getoptimum/mump2p-cli/main/install.sh | bash
 ```
 
-This script will:
-- Automatically detect your OS and architecture
-- Download the latest release binary
-- Make it executable and ready to use
-- Works on Linux and macOS
+**Manual Installation:**
+Download from [releases](https://github.com/getoptimum/mump2p-cli/releases/latest) and make executable.
 
-### Manual Installation
-
-Download the latest binary from [releases](https://github.com/getoptimum/mump2p-cli/releases/latest):
+### 2. Authentication
 
 ```sh
-# For macOS
-curl -L -o mump2p https://github.com/getoptimum/mump2p-cli/releases/latest/download/mump2p-mac
-
-# For Linux
-curl -L -o mump2p https://github.com/getoptimum/mump2p-cli/releases/latest/download/mump2p-linux
-
-chmod +x mump2p
+./mump2p login
+./mump2p whoami  # Check your session
 ```
 
-### Build from Source
+### 3. Basic Usage
 
 ```sh
-git clone https://github.com/getoptimum/mump2p-cli
-cd mump2p-cli
-# config ldflags
-export DOMAIN="xxx"
-export CLIENT_ID="xxx"
-export SERVICE_URL="xxx"
-make build
+# Subscribe to a topic
+./mump2p subscribe --topic=test-topic
 
-# or
-DOMAIN="xxx" CLIENT_ID="xxx" SERVICE_URL="xxx" make build
+# Publish a message
+./mump2p publish --topic=test-topic --message="Hello World"
 ```
+
+---
+
+## 📚 Documentation
+
+- **[Complete User Guide](./docs/guide.md)** - Detailed setup, authentication, and usage instructions
+
+---
 
 ## Version Compatibility
 
@@ -70,114 +64,6 @@ DOMAIN="xxx" CLIENT_ID="xxx" SERVICE_URL="xxx" make build
 **Deprecated Versions:**
 - ⚠️ **v0.0.1-rc2** and **v0.0.1-rc1** are deprecated and no longer supported
 - Please upgrade to **v0.0.1-rc3**
-
-## Authentication
-
-Before publishing or subscribing, login via device flow:
-
-```sh
-./mump2p login
-```
-
-To check the current session:
-
-```sh
-./mump2p whoami
-```
-
-To refresh the session token manually:
-
-```sh
-./mump2p refresh
-```
-
-To logout:
-
-```sh
-./mump2p logout
-```
-
-## Usage
-
-### Publish Message
-
-```sh
-./mump2p publish --topic=test-topic --message="new block 1234"
-```
-
-Message size and rate limits will be validated using the authenticated token claims. CLI do it internally.
-
-(optional, custom endpoint)
-
-```sh
-./mump2p publish --topic=test-topic --message="new block 1234" --service-url="https://your-custom-endpoint.com"
-```
-
-### Subscribe to a Topic
-
-```sh
-./mump2p subscribe --topic=test-topic
-```
-
-Subscribe and persist messages to a local file:
-
-```sh
-./mump2p subscribe --topic=test-topic --persist=/path/to/
-```
-
-Subscribe and forward messages to a webhook:
-
-```sh
-./mump2p subscribe --topic=test-topic --webhook=https://your-server.com/webhook
-```
-
-You can combine both persistence and webhook forwarding:
-
-```sh
-./mump2p subscribe --topic=test-topic --persist=/path/to/ --webhook=https://your-server.com/webhook
-```
-
-Advanced webhook options:
-
-```sh
-./mump2p subscribe --topic=test-topic --webhook=https://your-server.com/webhook --webhook-queue-size=200 --webhook-timeout=5
-```
-
-(optional, custom endpoint)
-
-```sh
-./mump2p subscribe --topic=test-topic --service-url="https://your-custom-endpoint.com"
-```
-
-here:
-
-- `--webhook-queue-size:` Max number of webhook messages to queue before dropping (default: 100)
-- `--webhook-timeout:` Timeout in seconds for each webhook POST request (default: 3)
-- `--service-url`: Optional custom service url
-
-## Check Rate Limits & Usage
-
-```sh
-./mump2p usage
-```
-
-This shows:
-
-- Current publish count
-- Daily data quota used
-- Time until reset
-- Token expiry info
-
-## Roadmap
-
-- [x] Publish Message
-- [x] Subscribe Message
-- [x] JWT-based login/logout/refresh
-- [x] Token-based rate limits
-- [x] Usage tracking (usage command)
-- [x] Real-time stream mode
-- [x] Message persistence
-- [x] Webhook forwarding
 
 ---
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -84,26 +84,6 @@ For a complete list of available proxies and their locations, see: [Available Se
 
 ---
 
-## Publishing Messages
-
-### Publish a Text Message
-
-To publish a simple text message to a topic:
-
-```sh
-./mump2p publish --topic=your-topic-name --message="Your message content"
-```
-
-### Publish a File
-
-To publish the contents of a file:
-
-```sh
-./mump2p publish --topic=your-topic-name --file=/path/to/your/file.json
-```
-
-Rate limits will be automatically applied based on your authentication token.
-
 ## Subscribing to Messages
 
 ### Basic Subscription
@@ -161,6 +141,28 @@ You can both save messages locally and forward them to a webhook:
   --persist=/path/to/messages.log \
   --webhook=https://your-server.com/webhook
 ```
+
+---
+
+## Publishing Messages
+
+### Publish a Text Message
+
+To publish a simple text message to a topic:
+
+```sh
+./mump2p publish --topic=your-topic-name --message="Your message content"
+```
+
+### Publish a File
+
+To publish the contents of a file:
+
+```sh
+./mump2p publish --topic=your-topic-name --file=/path/to/your/file.json
+```
+
+Rate limits will be automatically applied based on your authentication token.
 
 ---
 


### PR DESCRIPTION
- Remove duplicated usage sections from README
- Reorganize guide to put subscribing before publishing
- Make README more concise and direct users to detailed guide
- Improve documentation structure and flow