### PR TITLE
fix: typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO_BIN       ?= go
 CLI_NAME     := mump2p
 BUILD_DIR    := dist
 
-VERSION      ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")-rc
+VERSION      ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 COMMIT_HASH  ?= $(shell git rev-parse --short HEAD)
 DOMAIN       ?= ""
 CLIENT_ID    ?= ""


### PR DESCRIPTION
**Note:**  
Previously, a hard-coded `-rc` suffix was appended:

```make
VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")-rc
```
This caused every build to look like a release candidate.

The current setup `(git describe --tags --abbrev=0)` fixes that, but:

Doesn’t reflect off-tag commits → building two commits after v0.0.1 still reports v0.0.1.

Ignores dirty state → local changes aren’t visible in the version string.

For releases, this is clean and predictable.
For development builds, should consider improved versioning logic