### PR TITLE
Valentyn/cli common versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CLI_NAME     := mump2p
 BUILD_DIR    := dist
 
 VERSION      ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-COMMIT_HASH  ?= $(shell git rev-parse --short HEAD)
+COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DOMAIN       ?= ""
 CLIENT_ID    ?= ""
 AUDIENCE     ?= optimum-login

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ LD_FLAGS := -X github.com/getoptimum/mump2p-cli/internal/config.Domain=$(DOMAIN)
             -X github.com/getoptimum/mump2p-cli/internal/config.ClientID=$(CLIENT_ID) \
             -X github.com/getoptimum/mump2p-cli/internal/config.Audience=$(AUDIENCE) \
             -X github.com/getoptimum/mump2p-cli/internal/config.ServiceURL=$(SERVICE_URL) \
-            -X github.com/getoptimum/mump2p-cli/internal/config.Version=$(VERSION) \
-            -X github.com/getoptimum/mump2p-cli/internal/config.CommitHash=$(COMMIT_HASH)
+            -X github.com/getoptimum/optimum-common/version.Version=$(VERSION) \
+            -X github.com/getoptimum/optimum-common/version.CommitHash=$(COMMIT_HASH)
 
 .PHONY: all build run clean test help lint build tag release print-cli-name
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/getoptimum/mump2p-cli/internal/config"
+	"github.com/getoptimum/optimum-common/version"
 	"github.com/spf13/cobra"
 )
 
@@ -13,8 +13,8 @@ var versionCmd = &cobra.Command{
 	Short: "Show CLI version",
 	Long:  `Display the current version and Git commit used to build this binary.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Version:", config.Version)
-		fmt.Println("Commit: ", config.CommitHash)
+		fmt.Println("Version:", version.Version)
+		fmt.Println("Commit: ", version.CommitHash)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/getoptimum/mump2p-cli
 
-go 1.24.1
+go 1.24.6
 
 require (
+	github.com/getoptimum/optimum-common v0.0.0-20250820155834-aa661d810c90
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/getoptimum/optimum-common v0.0.0-20250820155834-aa661d810c90 h1:RhsUQzsut+McGjwyTR+qT0QHuOTnZN/+EXGkAghXHGs=
+github.com/getoptimum/optimum-common v0.0.0-20250820155834-aa661d810c90/go.mod h1:TAzGitXM3ONTQbETcwSBqd5c0E7kUgaQTJ6pMmqTa4k=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,8 +14,6 @@ const (
 
 // These will be injected at build time using -ldflags
 var (
-	Version    string // e.g., v0.0.1-rc1
-	CommitHash string // git commit hash
 	Domain     string
 	ClientID   string
 	Audience   string


### PR DESCRIPTION
Moves `Version` and `CommitHash` into `optimum-common/version`, injected via `-ldflags` during build. 
Removes duplicate logic
(+ added fallback for `CommitHash` in case built from tarball or w/o .git)