### PR TITLE
feat: add Release Drafter automation for release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,78 @@
+name-template: 'OptimumP2P CLI v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'feat'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📚 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+      - 'refactor'
+
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'documentation'
+      - 'chore'
+  default: patch
+
+template: |
+  # OptimumP2P CLI $RESOLVED_VERSION Release
+  
+  We're excited to announce the release of OptimumP2P CLI $RESOLVED_VERSION - command-line interface for our high-performance RLNC-enhanced pubsub protocol.
+  
+  ## 📦 Download & Install
+  
+  Get the latest binaries for your platform:
+  
+  **[Download Release $RESOLVED_VERSION](https://github.com/getoptimum/mump2p-cli/releases/tag/$RESOLVED_VERSION)**
+  
+  - `mump2p-linux` - Linux x86_64
+  - `mump2p-mac` - macOS x86_64
+  
+  **Quick Install:**
+  ```bash
+  curl -sSL https://raw.githubusercontent.com/getoptimum/mump2p-cli/main/install.sh | bash
+  ```
+  
+  ## 🔄 What's Changed
+  
+  $CHANGES
+  
+  ## 📖 Documentation & Resources
+  
+  - [User Guide](https://github.com/getoptimum/mump2p-cli/blob/main/docs/guide.md) - Step-by-step usage instructions
+  - [README](https://github.com/getoptimum/mump2p-cli/blob/main/README.md) - Complete overview and troubleshooting FAQ
+ 
+  
+
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Add Release Drafter Automation

Automates professional release note generation for partner communications.

### Changes
- Added Release Drafter workflow (triggers on main push)
- Added clean release note template 
- Includes download links, changes summary, and docs

### Benefits
- No more manual release note writing
- Partner-friendly format
- Integrates with existing `make tag` workflow