### PR TITLE
docs: improve the guide and README-guide connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 It supports authenticated publishing, subscribing, rate-limited usage tracking, and JWT session management.
 
-**[📖 Detailed User Guide - Complete step-by-step instructions for all features](./docs/guide.md)**
-
 ---
 
 ## Features


### PR DESCRIPTION
- Remove duplicate user guide link from README intro
- Restructure guide to assume README quick start completion
- Add context bridges throughout guide referencing README examples
- Replace redundant installation instructions with prerequisites
- Update all command outputs to match actual CLI responses
- Remove 'Advanced' terminology from authentication section
