### PR TITLE
feat: add customizable authentication file path support

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -24,7 +24,7 @@ var loginCmd = &cobra.Command{
 		}
 
 		// store token
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 		if err := storage.SaveToken(token); err != nil {
 			return err
 		}
@@ -41,7 +41,7 @@ var logoutCmd = &cobra.Command{
 	Short: "Log out from the P2P service",
 	Long:  `Remove the stored authentication token.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 		if err := storage.RemoveToken(); err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ var whoamiCmd = &cobra.Command{
 	Long:  `Display information about the current authentication token.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// load token
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 		token, err := storage.LoadToken()
 		if err != nil {
 			return fmt.Errorf("not authenticated: %v", err)
@@ -107,7 +107,7 @@ var refreshCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// create auth client and storage
 		authClient := auth.NewClient()
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 
 		// load current token
 		token, err := storage.LoadToken()

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -45,7 +45,7 @@ var publishCmd = &cobra.Command{
 		}
 
 		authClient := auth.NewClient()
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 		token, err := authClient.GetValidToken(storage)
 		if err != nil {
 			return fmt.Errorf("authentication required: %v", err)
@@ -79,7 +79,7 @@ var publishCmd = &cobra.Command{
 		// message size
 		messageSize := int64(len(data))
 
-		limiter, err := ratelimit.NewRateLimiter(claims)
+		limiter, err := ratelimit.NewRateLimiterWithDir(claims, GetAuthDir())
 		if err != nil {
 			return fmt.Errorf("rate limiter setup failed: %v", err)
 		}
@@ -155,7 +155,7 @@ var publishCmd = &cobra.Command{
 			fmt.Println(string(body))
 		}
 
-		if limiter, err := ratelimit.NewRateLimiter(claims); err == nil {
+		if limiter, err := ratelimit.NewRateLimiterWithDir(claims, GetAuthDir()); err == nil {
 			_ = limiter.RecordPublish(messageSize) // update quota (fail silently)
 		}
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	authPath string // Global flag for custom authentication file path
 )
 
 var rootCmd = &cobra.Command{
@@ -22,6 +27,23 @@ func Execute() {
 }
 
 func init() {
+	// Add global flag for custom authentication path
+	rootCmd.PersistentFlags().StringVar(&authPath, "auth-path", os.Getenv("MUMP2P_AUTH_PATH"), "Custom path for authentication file (default: ~/.optimum/auth.yml, env: MUMP2P_AUTH_PATH)")
+
 	// disable completion option
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+}
+
+// GetAuthPath returns the custom auth path if set, otherwise empty string
+func GetAuthPath() string {
+	return authPath
+}
+
+// GetAuthDir returns the directory for auth files (either custom or default ~/.optimum)
+func GetAuthDir() string {
+	if authPath != "" {
+		return filepath.Dir(authPath)
+	}
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, ".optimum")
 }

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -47,7 +47,7 @@ var subscribeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// auth
 		authClient := auth.NewClient()
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 		token, err := authClient.GetValidToken(storage)
 		if err != nil {
 			return fmt.Errorf("authentication required: %v", err)

--- a/cmd/usages.go
+++ b/cmd/usages.go
@@ -16,7 +16,7 @@ var usageCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// get valid token (refreshes if needed)
 		authClient := auth.NewClient()
-		storage := auth.NewStorage()
+		storage := auth.NewStorageWithPath(GetAuthPath())
 		token, err := authClient.GetValidToken(storage)
 		if err != nil {
 			return fmt.Errorf("authentication required: %v", err)
@@ -30,7 +30,7 @@ var usageCmd = &cobra.Command{
 		}
 
 		// initialize rate limiter
-		limiter, err := ratelimit.NewRateLimiter(claims)
+		limiter, err := ratelimit.NewRateLimiterWithDir(claims, GetAuthDir())
 		if err != nil {
 			return fmt.Errorf("error initializing rate limiter: %v", err)
 		}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -68,6 +68,38 @@ If your token is about to expire, you can refresh it:
 ./mump2p refresh
 ```
 
+### Custom Authentication File Location
+
+By default, authentication tokens are stored in `~/.optimum/auth.yml`. For production deployments, security requirements, or non-root users, you can customize this location:
+
+```sh
+# Use custom authentication file path
+./mump2p --auth-path /opt/mump2p/auth/token.yml login
+
+# All subsequent commands will use the same custom path
+./mump2p --auth-path /opt/mump2p/auth/token.yml publish --topic=demo --message="Hello"
+./mump2p --auth-path /opt/mump2p/auth/token.yml logout
+```
+
+**Environment Variable Support:**
+```sh
+# Set via environment variable (applies to all commands)
+export MUMP2P_AUTH_PATH="/opt/mump2p/auth/token.yml"
+./mump2p login
+./mump2p publish --topic=demo --message="Hello"
+```
+
+**Use Cases:**
+- **Security**: Store auth files in secure, restricted directories
+- **Deployment Automation**: Use with Ansible, Terraform without root permissions
+- **Multi-user Environments**: Separate auth files per user/service
+- **Container Deployments**: Mount auth files from persistent volumes
+
+**Important Notes:**
+- The directory will be created automatically if it doesn't exist
+- Rate limiting usage files will be stored in the same directory
+- Ensure the user has write permissions to the specified directory
+
 ### Logout
 
 To remove your stored authentication token:

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -17,9 +17,23 @@ type Storage struct {
 
 // NewStorage creates a new token storage
 func NewStorage() *Storage {
-	homeDir, _ := os.UserHomeDir()
-	tokenDir := filepath.Join(homeDir, ".optimum")
-	tokenFile := filepath.Join(tokenDir, "auth.yml")
+	return NewStorageWithPath("")
+}
+
+// NewStorageWithPath creates a new token storage with custom path
+func NewStorageWithPath(customPath string) *Storage {
+	var tokenDir, tokenFile string
+
+	if customPath != "" {
+		// If custom path is provided, use it directly
+		tokenFile = customPath
+		tokenDir = filepath.Dir(customPath)
+	} else {
+		// Default behavior: use ~/.optimum/auth.yml
+		homeDir, _ := os.UserHomeDir()
+		tokenDir = filepath.Join(homeDir, ".optimum")
+		tokenFile = filepath.Join(tokenDir, "auth.yml")
+	}
 
 	return &Storage{
 		tokenDir:  tokenDir,

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -22,9 +22,21 @@ type RateLimiter struct {
 
 // NewRateLimiter creates a new rate limiter
 func NewRateLimiter(claims *auth.TokenClaims) (*RateLimiter, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("could not determine home directory: %v", err)
+	return NewRateLimiterWithDir(claims, "")
+}
+
+// NewRateLimiterWithDir creates a new rate limiter with custom directory
+func NewRateLimiterWithDir(claims *auth.TokenClaims, customDir string) (*RateLimiter, error) {
+	var usageDir string
+	
+	if customDir != "" {
+		usageDir = customDir
+	} else {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("could not determine home directory: %v", err)
+		}
+		usageDir = filepath.Join(homeDir, ".optimum")
 	}
 
 	identifier := "default"
@@ -32,7 +44,6 @@ func NewRateLimiter(claims *auth.TokenClaims) (*RateLimiter, error) {
 		identifier = claims.Subject
 	}
 
-	usageDir := filepath.Join(homeDir, ".optimum")
 	usageFile := filepath.Join(usageDir, fmt.Sprintf("%s_usage.json", identifier))
 
 	if err := os.MkdirAll(usageDir, 0700); err != nil {


### PR DESCRIPTION
- Add `--auth-path` global flag for custom authentication file location
- Add `MUMP2P_AUTH_PATH` environment variable support  
- Maintain full backward compatibility with default `~/.optimum/auth.yml`
- Update rate limiter to use same custom directory structure
- Add documentation with usage examples
- Support deployment automation and non-root user scenarios