### PR TITLE
fix: handle is_active field as both string and boolean in JWT tokens

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -50,7 +50,7 @@ func (p *TokenParser) ParseToken(tokenString string) (*TokenClaims, error) {
 	}
 
 	tc := &TokenClaims{
-		IsActive:          claims["is_active"] == true,
+		IsActive:          isActiveFromClaims(claims),
 		MaxPublishPerHour: intFromClaims(claims, "max_publish_per_hour", config.DefaultMaxPublishPerHour),
 		MaxPublishPerSec:  intFromClaims(claims, "max_publish_per_sec", config.DefaultMaxPublishPerSec),
 		MaxMessageSize:    int64FromClaims(claims, "max_message_size", config.DefaultMaxMessageSize),
@@ -90,4 +90,20 @@ func int64FromClaims(c jwt.MapClaims, key string, def int64) int64 {
 		return int64(v)
 	}
 	return def
+}
+
+func isActiveFromClaims(c jwt.MapClaims) bool {
+	if v, ok := c["is_active"]; ok {
+		switch val := v.(type) {
+		case bool:
+			return val
+		case string:
+			return val == "true"
+		case int:
+			return val != 0
+		case float64:
+			return val != 0
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Problem
- Users getting "your account is inactive" error despite being activated in Auth0
- Issue started last week with existing RC4 binaries that were previously working
- Auth0 recently changed JWT token format: `is_active` now comes as string `"true"` instead of boolean `true`

## Cause

**In the existing code:**

```
IsActive: claims["is_active"] == true,
```