### PR TITLE
feat: add debug flag with detailed timing and proxy information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	authPath string // Global flag for custom authentication file path
+	debug    bool   // Global flag for debug mode
 )
 
 var rootCmd = &cobra.Command{
@@ -30,6 +31,9 @@ func init() {
 	// Add global flag for custom authentication path
 	rootCmd.PersistentFlags().StringVar(&authPath, "auth-path", os.Getenv("MUMP2P_AUTH_PATH"), "Custom path for authentication file (default: ~/.optimum/auth.yml, env: MUMP2P_AUTH_PATH)")
 
+	// Add global debug flag
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug mode with detailed timing and proxy information")
+
 	// disable completion option
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }
@@ -46,4 +50,9 @@ func GetAuthDir() string {
 	}
 	homeDir, _ := os.UserHomeDir()
 	return filepath.Join(homeDir, ".optimum")
+}
+
+// IsDebugMode returns true if debug mode is enabled
+func IsDebugMode() bool {
+	return debug
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"regexp"
+)
+
+// extractIPFromURL extracts IP address from URL string
+func extractIPFromURL(url string) string {
+	ipRegex := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)
+	return ipRegex.FindString(url)
+}


### PR DESCRIPTION
<img width="3059" height="1628" alt="image" src="https://github.com/user-attachments/assets/aa1c43ca-9a70-4a65-afb2-956515349b60" />
<img width="3361" height="1572" alt="image" src="https://github.com/user-attachments/assets/28755746-6ff9-40f2-a825-4aa6f76adea8" />
<img width="3039" height="1619" alt="image" src="https://github.com/user-attachments/assets/4be8822a-39fb-4de8-8c6c-3857b4db3676" />

- Add global --debug flag to root command
- Implement debug logging for publish operations (HTTP/gRPC)
- Implement debug logging for subscribe operations (WebSocket/gRPC)
- Add timestamp tracking for send/receive events
- Add proxy IP address extraction and display
- Add message size and hash tracking
- Add protocol identification (HTTP/gRPC/WebSocket)
- Add message numbering for received messages
- Extract sender info from debug prefix in received messages
- Create shared utility function for IP extraction
- Support both single message and blast publish testin