### PR TITLE
feat: implement gRPC subscription and improve URL display

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -123,46 +123,12 @@ var subscribeCmd = &cobra.Command{
 		// use custom service URL if provided, otherwise use the default
 		if subServiceURL != "" {
 			srcUrl = subServiceURL
-			fmt.Printf("Using custom service URL: %s\n", srcUrl)
 		}
 
-		// send HTTP POST subscription request first
-		fmt.Println("Sending HTTP POST subscription request...")
-		httpEndpoint := fmt.Sprintf("%s/api/v1/subscribe", srcUrl)
-		reqData := SubscribeRequest{
-			ClientID:  claims.ClientID,
-			Topic:     subTopic,
-			Threshold: subThreshold,
-		}
-		reqBytes, err := json.Marshal(reqData)
-		if err != nil {
-			return fmt.Errorf("failed to marshal subscription request: %v", err)
-		}
-
-		req, err := http.NewRequest("POST", httpEndpoint, bytes.NewBuffer(reqBytes))
-		if err != nil {
-			return fmt.Errorf("failed to create HTTP request: %v", err)
-		}
-		req.Header.Set("Authorization", "Bearer "+token.Token)
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("HTTP POST subscribe failed: %v", err)
-		}
-
-		defer resp.Body.Close() //nolint:errcheck
-		body, _ := io.ReadAll(resp.Body)
-
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("HTTP POST subscribe error: %s", string(body))
-		}
-
-		fmt.Printf("HTTP POST subscription successful: %s\n", string(body))
-
+		// Prepare gRPC address if needed
+		var grpcAddr string
 		if useGRPC {
-			// gRPC subscription logic
-			grpcAddr := strings.Replace(srcUrl, "http://", "", 1)
+			grpcAddr = strings.Replace(srcUrl, "http://", "", 1)
 			grpcAddr = strings.Replace(grpcAddr, "https://", "", 1)
 			// Replace the port with 50051 for gRPC (default gRPC port)
 			if strings.Contains(grpcAddr, ":") {
@@ -172,12 +138,15 @@ var subscribeCmd = &cobra.Command{
 			} else {
 				grpcAddr += ":50051" // default port if not specified
 			}
+			fmt.Printf("Using gRPC service URL: %s\n", grpcAddr)
+		} else {
+			fmt.Printf("Using HTTP service URL: %s\n", srcUrl)
+		}
 
-			// Extract receiver IP for debug mode
-			receiverAddr := extractIPFromURL(grpcAddr)
-			if receiverAddr == "" {
-				receiverAddr = grpcAddr // fallback to full address if no IP found
-			}
+		// send subscription request (HTTP or gRPC based on useGRPC flag)
+		if useGRPC {
+			// Use gRPC for subscription request
+			fmt.Println("Sending gRPC subscription request...")
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -187,9 +156,70 @@ var subscribeCmd = &cobra.Command{
 			}
 			defer client.Close()
 
-			msgChan, err := client.Subscribe(ctx, claims.ClientID, grpcBufferSize)
+			err = client.SubscribeTopic(ctx, claims.ClientID, subTopic, subThreshold)
 			if err != nil {
 				return fmt.Errorf("gRPC subscribe failed: %v", err)
+			}
+
+			fmt.Printf("gRPC subscription successful: subscribed to topic '%s'\n", subTopic)
+		} else {
+			// Use HTTP for subscription request
+			fmt.Println("Sending HTTP POST subscription request...")
+			httpEndpoint := fmt.Sprintf("%s/api/v1/subscribe", srcUrl)
+			reqData := SubscribeRequest{
+				ClientID:  claims.ClientID,
+				Topic:     subTopic,
+				Threshold: subThreshold,
+			}
+			reqBytes, err := json.Marshal(reqData)
+			if err != nil {
+				return fmt.Errorf("failed to marshal subscription request: %v", err)
+			}
+
+			req, err := http.NewRequest("POST", httpEndpoint, bytes.NewBuffer(reqBytes))
+			if err != nil {
+				return fmt.Errorf("failed to create HTTP request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+token.Token)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("HTTP POST subscribe failed: %v", err)
+			}
+
+			defer resp.Body.Close() //nolint:errcheck
+			body, _ := io.ReadAll(resp.Body)
+
+			if resp.StatusCode != 200 {
+				return fmt.Errorf("HTTP POST subscribe error: %s", string(body))
+			}
+
+			fmt.Printf("HTTP POST subscription successful: %s\n", string(body))
+		}
+
+		if useGRPC {
+			// gRPC streaming logic (reuse the connection from subscription)
+			// Extract receiver IP for debug mode
+			receiverAddr := extractIPFromURL(grpcAddr)
+			if receiverAddr == "" {
+				receiverAddr = grpcAddr // fallback to full address if no IP found
+			}
+
+			// Create a new context for streaming (separate from subscription context)
+			streamCtx, streamCancel := context.WithCancel(context.Background())
+			defer streamCancel()
+
+			// Create a new client connection for streaming
+			streamClient, err := grpcsub.NewProxyClient(grpcAddr)
+			if err != nil {
+				return fmt.Errorf("failed to connect to gRPC proxy for streaming: %v", err)
+			}
+			defer streamClient.Close()
+
+			msgChan, err := streamClient.Subscribe(streamCtx, claims.ClientID, grpcBufferSize)
+			if err != nil {
+				return fmt.Errorf("gRPC stream subscribe failed: %v", err)
 			}
 
 			fmt.Printf("Listening for messages on topic '%s' via gRPC... Press Ctrl+C to exit\n", subTopic)
@@ -260,7 +290,7 @@ var subscribeCmd = &cobra.Command{
 			select {
 			case <-sigChan:
 				fmt.Println("\nClosing connection...")
-				cancel()
+				streamCancel()
 			case <-doneChan:
 				fmt.Println("\nConnection closed by server")
 			}

--- a/internal/grpc/proxy_client.go
+++ b/internal/grpc/proxy_client.go
@@ -87,6 +87,26 @@ func (pc *ProxyClient) Close() error {
 	return pc.conn.Close()
 }
 
+// SubscribeTopic sends a gRPC subscription request to register for a topic
+func (pc *ProxyClient) SubscribeTopic(ctx context.Context, clientID, topic string, threshold float32) error {
+	req := &proto.SubscribeRequest{
+		ClientId:  clientID,
+		Topic:     topic,
+		Threshold: threshold,
+	}
+
+	resp, err := pc.client.Subscribe(ctx, req)
+	if err != nil {
+		return fmt.Errorf("gRPC subscribe failed: %v", err)
+	}
+
+	if resp.Status != "subscribed" {
+		return fmt.Errorf("subscribe failed with status: %s", resp.Status)
+	}
+
+	return nil
+}
+
 // Publish sends a message to a topic via gRPC
 func (pc *ProxyClient) Publish(ctx context.Context, clientID, topic string, message []byte) error {
 	req := &proto.PublishRequest{


### PR DESCRIPTION
- Add gRPC subscription support to subscribe command
- Implement SubscribeTopic method in proxy_client.go
- Improve URL display to show actual gRPC address (port 50051) vs HTTP URL
- Fix streamCancel reference in subscribe.go

https://github.com/user-attachments/assets/6bd07763-ceac-4574-8674-751f838d6557



