### PR TITLE
refactor: beautification for naming convention - OptimumP2P to mumP2P

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 # Release Drafter should only create drafts - we manage actual releases via Makefile
-name-template: 'OptimumP2P CLI [DRAFT - Update Version Before Publishing]'
+name-template: 'mumP2P CLI [DRAFT - Update Version Before Publishing]'
 tag-template: '[UPDATE-TAG-BEFORE-PUBLISHING]'
 
 # Include pre-releases to track all our RC versions
@@ -87,9 +87,9 @@ autolabeler:
       - 'package-lock.json'
 
 template: |
-  # OptimumP2P CLI v[UPDATE-VERSION] Release
+  # mumP2P CLI v[UPDATE-VERSION] Release
   
-  We're excited to announce the release of OptimumP2P CLI v[UPDATE-VERSION] - command-line interface for our high-performance RLNC-enhanced pubsub protocol.
+  We're excited to announce the release of mumP2P CLI v[UPDATE-VERSION] - command-line interface for our high-performance RLNC-enhanced pubsub protocol.
   
   ## 📦 Download & Install
   

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -89,7 +89,7 @@ autolabeler:
 template: |
   # mumP2P CLI v[UPDATE-VERSION] Release
   
-  We're excited to announce the release of mumP2P CLI v[UPDATE-VERSION] - command-line interface for our high-performance RLNC-enhanced pubsub protocol.
+  We're excited to announce the release of mumP2P CLI v[UPDATE-VERSION] - command-line interface for our high-performance RLNC-enhanced pubsub network.
   
   ## 📦 Download & Install
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mump2p — mumP2P CLI
+# mump2p CLI
 
-`mump2p` is the command-line interface for interacting with [mumP2P](https://github.com/getoptimum/optimum-p2p) — a high-performance RLNC-enhanced pubsub protocol.
+`mump2p-cli` is the command-line interface for interacting with [mumP2P protocol](https://github.com/getoptimum/optimum-p2p) — a high-performance RLNC-enhanced pubsub protocol.
 
 It supports authenticated publishing, subscribing, rate-limited usage tracking, and JWT session management.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mump2p CLI
 
-`mump2p-cli` is the command-line interface for interacting with [mumP2P protocol](https://github.com/getoptimum/optimum-p2p) — a high-performance RLNC-enhanced pubsub protocol.
+`mump2p-cli` is the command-line interface for interacting with [Optimum network](https://github.com/getoptimum/optimum-p2p) — a high-performance RLNC-enhanced pubsub network.
 
 It supports authenticated publishing, subscribing, rate-limited usage tracking, and JWT session management.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mump2p — OptimumP2P CLI
+# mump2p — mumP2P CLI
 
-`mump2p` is the command-line interface for interacting with [OptimumP2P](https://github.com/getoptimum/optimum-p2p) — a high-performance RLNC-enhanced pubsub protocol.
+`mump2p` is the command-line interface for interacting with [mumP2P](https://github.com/getoptimum/optimum-p2p) — a high-performance RLNC-enhanced pubsub protocol.
 
 It supports authenticated publishing, subscribing, rate-limited usage tracking, and JWT session management.
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -60,7 +60,7 @@ func printDebugInfo(data []byte, proxyAddr string, topic string, isGRPC bool) {
 
 var publishCmd = &cobra.Command{
 	Use:   "publish",
-	Short: "Publish a message to the mumP2P via HTTP or gRPC",
+	Short: "Publish a message to the Optimum Network via HTTP or gRPC",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if pubMessage == "" && file == "" {
 			return errors.New("either --message or --file must be provided")

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -60,7 +60,7 @@ func printDebugInfo(data []byte, proxyAddr string, topic string, isGRPC bool) {
 
 var publishCmd = &cobra.Command{
 	Use:   "publish",
-	Short: "Publish a message to the OptimumP2P via HTTP or gRPC",
+	Short: "Publish a message to the mumP2P via HTTP or gRPC",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if pubMessage == "" && file == "" {
 			return errors.New("either --message or --file must be provided")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,8 +15,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "mump2p",
-	Short: "CLI to interact with OptimumP2P directly via Go",
-	Long: `mump2p is a developer tool for interacting with OptimumP2P
+	Short: "CLI to interact with mumP2P directly via Go",
+	Long: `mump2p is a developer tool for interacting with mumP2P
 without relying on the HTTP server. It directly invokes Go services.`,
 }
 
@@ -29,7 +29,7 @@ func Execute() {
 
 func init() {
 	// Add global flag for custom authentication path
-	rootCmd.PersistentFlags().StringVar(&authPath, "auth-path", os.Getenv("MUMP2P_AUTH_PATH"), "Custom path for authentication file (default: ~/.optimum/auth.yml, env: MUMP2P_AUTH_PATH)")
+	rootCmd.PersistentFlags().StringVar(&authPath, "auth-path", os.Getenv("MUMP2P_AUTH_PATH"), "Custom path for authentication file (default: ~/.mump2p/auth.yml, env: MUMP2P_AUTH_PATH)")
 
 	// Add global debug flag
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug mode with detailed timing and proxy information")
@@ -43,13 +43,13 @@ func GetAuthPath() string {
 	return authPath
 }
 
-// GetAuthDir returns the directory for auth files (either custom or default ~/.optimum)
+// GetAuthDir returns the directory for auth files (either custom or default ~/.mump2p)
 func GetAuthDir() string {
 	if authPath != "" {
 		return filepath.Dir(authPath)
 	}
 	homeDir, _ := os.UserHomeDir()
-	return filepath.Join(homeDir, ".optimum")
+	return filepath.Join(homeDir, ".mump2p")
 }
 
 // IsDebugMode returns true if debug mode is enabled

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,8 +15,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "mump2p",
-	Short: "CLI to interact with mumP2P directly via Go",
-	Long: `mump2p is a developer tool for interacting with mumP2P
+	Short: "CLI to interact with Optimum directly via Go",
+	Long: `mump2p is a developer tool for interacting with Optimum
 without relying on the HTTP server. It directly invokes Go services.`,
 }
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -70,7 +70,7 @@ If your token is about to expire, you can refresh it:
 
 ### Custom Authentication File Location
 
-By default, authentication tokens are stored in `~/.optimum/auth.yml`. For production deployments, security requirements, or non-root users, you can customize this location:
+By default, authentication tokens are stored in `~/.mump2p/auth.yml`. For production deployments, security requirements, or non-root users, you can customize this location:
 
 ```sh
 # Use custom authentication file path

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -30,9 +30,9 @@ func NewStorageWithPath(customPath string) *Storage {
 		tokenFile = expandHomePath(customPath)
 		tokenDir = filepath.Dir(tokenFile)
 	} else {
-		// Default behavior: use ~/.optimum/auth.yml
+		// Default behavior: use ~/.mump2p/auth.yml
 		homeDir, _ := os.UserHomeDir()
-		tokenDir = filepath.Join(homeDir, ".optimum")
+		tokenDir = filepath.Join(homeDir, ".mump2p")
 		tokenFile = filepath.Join(tokenDir, "auth.yml")
 	}
 

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -163,8 +163,8 @@ func TestNewStorageWithPathTildeExpansion(t *testing.T) {
 
 	t.Run("empty path uses default", func(t *testing.T) {
 		storage := NewStorageWithPath("")
-		expectedFile := filepath.Join(homeDir, ".optimum/auth.yml")
-		expectedDir := filepath.Join(homeDir, ".optimum")
+		expectedFile := filepath.Join(homeDir, ".mump2p/auth.yml")
+		expectedDir := filepath.Join(homeDir, ".mump2p")
 
 		require.Equal(t, expectedFile, storage.tokenFile)
 		require.Equal(t, expectedDir, storage.tokenDir)

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -28,7 +28,7 @@ func NewRateLimiter(claims *auth.TokenClaims) (*RateLimiter, error) {
 // NewRateLimiterWithDir creates a new rate limiter with custom directory
 func NewRateLimiterWithDir(claims *auth.TokenClaims, customDir string) (*RateLimiter, error) {
 	var usageDir string
-	
+
 	if customDir != "" {
 		usageDir = customDir
 	} else {
@@ -36,7 +36,7 @@ func NewRateLimiterWithDir(claims *auth.TokenClaims, customDir string) (*RateLim
 		if err != nil {
 			return nil, fmt.Errorf("could not determine home directory: %v", err)
 		}
-		usageDir = filepath.Join(homeDir, ".optimum")
+		usageDir = filepath.Join(homeDir, ".mump2p")
 	}
 
 	identifier := "default"

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -23,7 +23,7 @@ func createTestClaims() *auth.TokenClaims {
 
 func cleanupUsageFile(claims *auth.TokenClaims) {
 	homeDir, _ := os.UserHomeDir()
-	path := filepath.Join(homeDir, ".optimum", claims.Subject+"_usage.json")
+	path := filepath.Join(homeDir, ".mump2p", claims.Subject+"_usage.json")
 	_ = os.Remove(path)
 }
 


### PR DESCRIPTION
- Update README.md: OptimumP2P CLI → mumP2P CLI branding
- Update CLI help text: All command descriptions now use mumP2P
- Update auth directory: ~/.optimum → ~/.mump2p for consistency
- Update rate limiting directory: ~/.optimum → ~/.mump2p
- Update GitHub release drafter: mumP2P CLI branding
- Update documentation: guide.md auth path references
- Update all auth storage and tests to use new directory structure