### PR TITLE
feat: add --disable-auth flag for development/testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Download from [releases](https://github.com/getoptimum/mump2p-cli/releases/lates
 
 **Development/Testing Mode:**
 ```sh
-# Skip authentication for testing (requires --service-url for network operations)
-./mump2p --disable-auth publish --topic=test --message="Hello" --service-url="http://34.146.222.111:8080"
-./mump2p --disable-auth subscribe --topic=test --service-url="http://34.146.222.111:8080"
+# Skip authentication for testing (requires --client-id and --service-url)
+./mump2p --disable-auth --client-id="my-test-client" publish --topic=test --message="Hello" --service-url="http://34.146.222.111:8080"
+./mump2p --disable-auth --client-id="my-test-client" subscribe --topic=test --service-url="http://34.146.222.111:8080"
+./mump2p --disable-auth --client-id="my-test-client" list-topics --service-url="http://34.146.222.111:8080"
 ```
 
 ### 3. Basic Usage
@@ -251,7 +252,20 @@ Error: required flag(s) "topic" not set
 - Include all required arguments
 - Check flag spelling and syntax
 
-### **6. Debug Mode & Performance Analysis**
+### **6. Development Mode (`--disable-auth`)**
+
+For development and testing, you can bypass authentication:
+
+```sh
+# Requires --client-id and --service-url flags
+./mump2p --disable-auth --client-id="test-client" \
+  publish --topic=test --message="Hello" \
+  --service-url="http://34.146.222.111:8080"
+```
+
+> **Note:** This mode is for testing only. No rate limits enforced. See [guide](./docs/guide.md) for full details.
+
+### **7. Debug Mode & Performance Analysis**
 
 The `--debug` flag provides detailed timing and proxy information for troubleshooting:
 
@@ -259,6 +273,11 @@ The `--debug` flag provides detailed timing and proxy information for troublesho
 # Enable debug mode for operations
 ./mump2p --debug publish --topic=test-topic --message='Hello World'
 ./mump2p --debug subscribe --topic=test-topic
+
+# Combine with --disable-auth for testing
+./mump2p --disable-auth --client-id="test" --debug \
+  publish --topic=test --message="Hello" \
+  --service-url="http://34.146.222.111:8080"
 ```
 
 For comprehensive debug mode usage, performance analysis, and blast testing examples, see the [Complete User Guide](./docs/guide.md#debug-mode).

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -58,17 +58,17 @@ var whoamiCmd = &cobra.Command{
 	Long:  `Display information about the current authentication token.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if IsAuthDisabled() {
-			// Display mock authentication status when auth is disabled
+			// Display authentication status when auth is disabled
+			clientIDToUse := GetClientID()
+			if clientIDToUse == "" {
+				clientIDToUse = "(not set - use --client-id flag)"
+			}
 			fmt.Println("Authentication Status:")
 			fmt.Println("----------------------")
-			fmt.Println("Client ID: mock-client-id (auth disabled)")
-			fmt.Println("Is Active: true (auth disabled)")
-			fmt.Println("Rate Limits:")
-			fmt.Println("  Max Publish Per Hour: 1000")
-			fmt.Println("  Max Publish Per Sec:  100")
-			fmt.Println("  Max Message Size:     1 MB")
-			fmt.Println("  Daily Quota:          100 MB")
-			fmt.Println("Token Expires: N/A (auth disabled)")
+			fmt.Printf("Client ID: %s\n", clientIDToUse)
+			fmt.Println("Auth Mode: Disabled (using --disable-auth)")
+			fmt.Println("Rate Limits: N/A (no limits enforced)")
+			fmt.Println("Token: N/A (auth disabled)")
 			return nil
 		}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,7 +29,12 @@ var listTopicsCmd = &cobra.Command{
 This command shows your active topics and their count.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if IsAuthDisabled() {
-			// When auth is disabled, we still need to make the API call
+			// When auth is disabled, require client-id flag
+			clientIDToUse := GetClientID()
+			if clientIDToUse == "" {
+				return fmt.Errorf("--client-id is required when using --disable-auth")
+			}
+
 			// Determine service URL
 			serviceURL := config.LoadConfig().ServiceUrl
 			if listServiceURL != "" {
@@ -37,8 +42,8 @@ This command shows your active topics and their count.`,
 				fmt.Printf("Using custom service URL: %s\n", serviceURL)
 			}
 
-			// Create HTTP GET request to /api/v1/topics (no client_id needed when auth is disabled)
-			endpoint := fmt.Sprintf("%s/api/v1/topics", serviceURL)
+			// Create HTTP GET request to /api/v1/topics with client_id query parameter
+			endpoint := fmt.Sprintf("%s/api/v1/topics?client_id=%s", serviceURL, clientIDToUse)
 			req, err := http.NewRequest("GET", endpoint, nil)
 			if err != nil {
 				return fmt.Errorf("failed to create HTTP request: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ var (
 	authPath    string // Global flag for custom authentication file path
 	debug       bool   // Global flag for debug mode
 	disableAuth bool   // Global flag to disable authentication checks
+	clientID    string // Global flag for client ID (used when auth is disabled)
 )
 
 var rootCmd = &cobra.Command{
@@ -35,6 +36,9 @@ func init() {
 
 	// Add global disable auth flag
 	rootCmd.PersistentFlags().BoolVar(&disableAuth, "disable-auth", false, "Disable authentication checks (for testing/development)")
+
+	// Add global client ID flag
+	rootCmd.PersistentFlags().StringVar(&clientID, "client-id", "", "Client ID to use (required when --disable-auth is enabled)")
 
 	// disable completion option
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
@@ -62,4 +66,9 @@ func IsDebugMode() bool {
 // IsAuthDisabled returns true if authentication is disabled
 func IsAuthDisabled() bool {
 	return disableAuth
+}
+
+// GetClientID returns the client ID when auth is disabled
+func GetClientID() string {
+	return clientID
 }

--- a/cmd/usages.go
+++ b/cmd/usages.go
@@ -15,38 +15,10 @@ var usageCmd = &cobra.Command{
 	Short: "Display usage statistics and rate limits",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if IsAuthDisabled() {
-			// Create mock claims for disabled auth and initialize rate limiter
-			mockClaims := &auth.TokenClaims{
-				IsActive:          true,
-				ClientID:          "mock-client-id",
-				MaxPublishPerHour: 1000, // Set reasonable limits for testing
-				MaxPublishPerSec:  10,
-				MaxMessageSize:    10 * 1024 * 1024,  // 10MB
-				DailyQuota:        100 * 1024 * 1024, // 100MB
-			}
-
-			// Initialize rate limiter with mock claims
-			limiter, err := ratelimit.NewRateLimiterWithDir(mockClaims, GetAuthDir())
-			if err != nil {
-				return fmt.Errorf("error initializing rate limiter: %v", err)
-			}
-
-			// get usage statistics
-			stats := limiter.GetUsageStats()
-
-			// display usage statistics
-			fmt.Println("Usage Statistics (Auth Disabled):")
-			fmt.Printf("  Publish (hour):     %d / %d\n", stats.PublishCount, stats.PublishLimitPerHour)
-			fmt.Printf("  Publish (second):   %d / %d\n", stats.SecondPublishCount, stats.PublishLimitPerSec)
-			fmt.Printf("  Data Used:          %.4f MB / %.4f MB\n", float64(stats.BytesPublished)/(1<<20), float64(stats.DailyQuota)/(1<<20))
-			fmt.Printf("  Next Reset:         %s (%s from now)\n", stats.NextReset.Format(time.RFC822), stats.TimeUntilReset)
-
-			if !stats.LastPublishTime.IsZero() {
-				fmt.Printf("  Last Publish:       %s\n", stats.LastPublishTime.Format(time.RFC822))
-			}
-			if !stats.LastSubscribeTime.IsZero() {
-				fmt.Printf("  Last Subscribe:     %s\n", stats.LastSubscribeTime.Format(time.RFC822))
-			}
+			// When auth is disabled, usage tracking is not available
+			fmt.Println("Usage Statistics:")
+			fmt.Println("  Status: Usage tracking disabled (using --disable-auth)")
+			fmt.Println("  No rate limits or quotas are enforced in this mode")
 			return nil
 		}
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -106,20 +106,28 @@ export MUMP2P_AUTH_PATH="/opt/mump2p/auth/token.yml"
 For development and testing scenarios, you can bypass authentication entirely using the `--disable-auth` flag:
 
 ```sh
-# All commands work without login (requires --service-url for network operations)
-./mump2p --disable-auth whoami
-./mump2p --disable-auth publish --topic=test --message="Hello" --service-url="http://34.146.222.111:8080"
-./mump2p --disable-auth subscribe --topic=test --service-url="http://34.146.222.111:8080"
-./mump2p --disable-auth list-topics --service-url="http://34.146.222.111:8080"
+# All commands work without login (requires --client-id and --service-url)
+./mump2p --disable-auth --client-id="my-test-client" whoami
+./mump2p --disable-auth --client-id="my-test-client" publish --topic=test --message="Hello" --service-url="http://34.146.222.111:8080"
+./mump2p --disable-auth --client-id="my-test-client" subscribe --topic=test --service-url="http://34.146.222.111:8080"
+./mump2p --disable-auth --client-id="my-test-client" list-topics --service-url="http://34.146.222.111:8080"
 ./mump2p --disable-auth usage
+
+# Works with gRPC too
+./mump2p --disable-auth --client-id="my-test-client" --grpc publish --topic=test --message="Hello" --service-url="http://34.146.222.111:8080"
+./mump2p --disable-auth --client-id="my-test-client" --grpc subscribe --topic=test --service-url="http://34.146.222.111:8080"
+
+# Combine with debug mode
+./mump2p --disable-auth --client-id="my-test-client" --debug publish --topic=test --message="Hello" --service-url="http://34.146.222.111:8080"
 ```
 
 **When using `--disable-auth`:**
-- Uses mock client ID (`mock-client-id`)
-- Unlimited rate limits for testing
+- **Must provide `--client-id` flag** with your chosen client ID
+- No rate limits enforced (bypasses all quotas)
+- No usage tracking
 - All functionality works without authentication
-- **Requires `--service-url` for network operations** (publish, subscribe, list)
-- Perfect for development and testing
+- **Requires `--service-url` for network operations** (publish, subscribe, list-topics)
+- Works with both HTTP/WebSocket and gRPC protocols
 
 ### Logout
 


### PR DESCRIPTION
- Add global --disable-auth flag to bypass authentication
- Mock authentication with mock-client-id when flag is set
- All commands work without login when --disable-auth is used
- Maintains full functionality: publish, subscribe, health, etc.
- Fixed rate limiting display to show actual seconds