### PR TITLE
feat: rename list command to list-topics and improve flag descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Download from [releases](https://github.com/getoptimum/mump2p-cli/releases/lates
 ./mump2p publish --topic=test-topic --message='Hello World' --grpc
 
 # List your active topics
-./mump2p list
+./mump2p list-topics
 
 # Debug mode - detailed timing and proxy information
 ./mump2p --debug publish --topic=test-topic --message='Hello World'

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,8 +22,8 @@ type ListResponse struct {
 	Count    int      `json:"count"`
 }
 
-var listCmd = &cobra.Command{
-	Use:   "list",
+var listTopicsCmd = &cobra.Command{
+	Use:   "list-topics",
 	Short: "List subscribed topics for the authenticated client",
 	Long: `List all topics that the authenticated client is currently subscribed to.
 This command shows your active topics and their count.`,
@@ -111,6 +111,6 @@ This command shows your active topics and their count.`,
 }
 
 func init() {
-	listCmd.Flags().StringVar(&listServiceURL, "service-url", "", "Override the default service URL")
-	rootCmd.AddCommand(listCmd)
+	listTopicsCmd.Flags().StringVar(&listServiceURL, "service-url", "", "Override the default service URL")
+	rootCmd.AddCommand(listTopicsCmd)
 }

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -224,8 +224,8 @@ var publishCmd = &cobra.Command{
 
 func init() {
 	publishCmd.Flags().StringVar(&pubTopic, "topic", "", "Topic to publish to")
-	publishCmd.Flags().StringVar(&pubMessage, "message", "", "Message string (should be more than allowed size)")
-	publishCmd.Flags().StringVar(&file, "file", "", "File (should be more than allowed size)")
+	publishCmd.Flags().StringVar(&pubMessage, "message", "", "Message string to publish")
+	publishCmd.Flags().StringVar(&file, "file", "", "File to publish")
 	publishCmd.Flags().StringVar(&serviceURL, "service-url", "", "Override the default service URL")
 	publishCmd.Flags().BoolVar(&useGRPCPub, "grpc", false, "Use gRPC for publishing instead of HTTP")
 	publishCmd.MarkFlagRequired("topic") //nolint:errcheck

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -224,8 +224,8 @@ var publishCmd = &cobra.Command{
 
 func init() {
 	publishCmd.Flags().StringVar(&pubTopic, "topic", "", "Topic to publish to")
-	publishCmd.Flags().StringVar(&pubMessage, "message", "", "Message string to publish")
-	publishCmd.Flags().StringVar(&file, "file", "", "File to publish")
+	publishCmd.Flags().StringVar(&pubMessage, "message", "", "Message string to publish (max 10MB)")
+	publishCmd.Flags().StringVar(&file, "file", "", "Path of the file to publish (max 10MB)")
 	publishCmd.Flags().StringVar(&serviceURL, "service-url", "", "Override the default service URL")
 	publishCmd.Flags().BoolVar(&useGRPCPub, "grpc", false, "Use gRPC for publishing instead of HTTP")
 	publishCmd.MarkFlagRequired("topic") //nolint:errcheck

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -135,7 +135,7 @@ Using custom service URL: http://34.142.205.26:8080
 
 ## Subscribing to Messages - Deep Dive
 
-*You've already tried basic subscription from the README. This section covers advanced options, protocols, and configuration.*
+*You've already tried basic topic subscription from the README. This section covers advanced options, protocols, and configuration.*
 
 ### Understanding WebSocket vs gRPC
 
@@ -598,7 +598,7 @@ Recv: [2] receiver_addr:34.146.222.111 [recv_time, size]:[1757606701424812000, 2
 1. **Topic Names:** Choose descriptive and unique topic names to avoid message conflicts
 2. **Message Size:** Be aware of your maximum message size limit when publishing files
 3. **Token Refresh:** For long-running operations, refresh your token before it expires
-4. **Topic Management:** Use `./mump2p list-topics` to check your active topics and avoid duplicate subscriptions
+4. **Topic Management:** Use `./mump2p list-topics` to check your active topics and avoid duplicate topic subscriptions
 5. **Persistent Subscriptions:** Use the --persist option when you need a record of messages
 6. **Webhook Reliability:** Increase the queue size for high-volume topics to prevent message drops
 7. **gRPC Performance:** Use `--grpc` flag for high-throughput scenarios and better performance

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -369,7 +369,7 @@ Rate limits will be automatically applied based on your authentication token.
 To see all topics you're currently subscribed to:
 
 ```sh
-./mump2p list
+./mump2p list-topics
 ```
 
 This will display:
@@ -405,7 +405,7 @@ This will display:
 You can check your topics on a specific proxy server:
 
 ```sh
-./mump2p list --service-url="http://35.221.118.95:8080"
+./mump2p list-topics --service-url="http://35.221.118.95:8080"
 ```
 
 **Example output:**
@@ -598,12 +598,12 @@ Recv: [2] receiver_addr:34.146.222.111 [recv_time, size]:[1757606701424812000, 2
 1. **Topic Names:** Choose descriptive and unique topic names to avoid message conflicts
 2. **Message Size:** Be aware of your maximum message size limit when publishing files
 3. **Token Refresh:** For long-running operations, refresh your token before it expires
-4. **Topic Management:** Use `./mump2p list` to check your active topics and avoid duplicate subscriptions
+4. **Topic Management:** Use `./mump2p list-topics` to check your active topics and avoid duplicate subscriptions
 5. **Persistent Subscriptions:** Use the --persist option when you need a record of messages
 6. **Webhook Reliability:** Increase the queue size for high-volume topics to prevent message drops
 7. **gRPC Performance:** Use `--grpc` flag for high-throughput scenarios and better performance
 8. **Health Monitoring:** Check proxy health with `./mump2p health` before long operations
-9. **Multi-Proxy Usage:** Remember that each proxy server maintains separate topic states - use `./mump2p list --service-url=<url>` to check topics on specific proxies
+9. **Multi-Proxy Usage:** Remember that each proxy server maintains separate topic states - use `./mump2p list-topics --service-url=<url>` to check topics on specific proxies
 10. **Debug Analysis:** Use `--debug` flag for performance monitoring and troubleshooting message flow issues
 
 ## Troubleshooting
@@ -615,8 +615,8 @@ For common setup and usage issues, see the [FAQ section in the README](../README
 - **Authentication Errors:** Run `./mump2p whoami` to check token status, and `./mump2p login` to re-authenticate
 - **Rate Limit Errors:** Use `./mump2p usage` to check your current usage against limits
 - **Topic Issues:** 
-  - Use `./mump2p list` to verify your active topics
-  - Check topics on different proxies with `./mump2p list --service-url=<url>`
+  - Use `./mump2p list-topics` to verify your active topics
+  - Check topics on different proxies with `./mump2p list-topics --service-url=<url>`
   - Remember that topics persist across logout/login sessions
 - **Connection Issues:** 
   - Verify your internet connection and firewall settings


### PR DESCRIPTION
- Rename 'list' command to 'list-topics' for better clarity
- Update all documentation (README.md, guide.md) with new command name
- Fix confusing flag descriptions in publish command:
  - --message: 'Message string to publish' (was: 'should be more than allowed size')
  - --file: 'File to publish' (was: 'should be more than allowed size')