### PR TITLE
feat(cli): add update command to install latest release

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,328 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/getoptimum/mump2p-cli/internal/config"
+	"github.com/getoptimum/mump2p-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+type GitHubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+var (
+	forceUpdate bool
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update CLI to the latest version",
+	Long: `Update the mump2p CLI to the latest version from GitHub releases.
+This command checks for updates, downloads the latest binary, and replaces the current installation.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Checking for updates...")
+
+		currentVersion := config.Version
+		if currentVersion == "" {
+			currentVersion = "unknown"
+		}
+		fmt.Printf("Current version: %s\n", currentVersion)
+
+		latestRelease, err := fetchLatestRelease()
+		if err != nil {
+			return fmt.Errorf("failed to fetch latest release: %w", err)
+		}
+
+		latestVersion := latestRelease.TagName
+		fmt.Printf("Latest version: %s\n", latestVersion)
+
+		if !forceUpdate && currentVersion == latestVersion {
+			fmt.Println("✅ You are already on the latest version!")
+			return nil
+		}
+
+		if !forceUpdate && currentVersion != "unknown" {
+			if version.Compare(currentVersion, latestVersion) >= 0 {
+				fmt.Println("✅ You are already on the latest version!")
+				return nil
+			}
+		}
+
+		fmt.Printf("Updating from %s to %s...\n", currentVersion, latestVersion)
+
+		execPath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("failed to get executable path: %w", err)
+		}
+
+		actualPath, err := filepath.EvalSymlinks(execPath)
+		if err != nil {
+			actualPath = execPath
+		}
+
+		binaryName, err := getBinaryNameForOS()
+		if err != nil {
+			return err
+		}
+
+		downloadURL := ""
+		for _, asset := range latestRelease.Assets {
+			if asset.Name == binaryName {
+				downloadURL = asset.BrowserDownloadURL
+				break
+			}
+		}
+
+		if downloadURL == "" {
+			return fmt.Errorf("binary %s not found in release %s. Available assets: %v",
+				binaryName, latestVersion, getAssetNames(latestRelease.Assets))
+		}
+
+		fmt.Printf("Downloading %s...\n", binaryName)
+
+		tempFile, err := downloadBinary(downloadURL)
+		if err != nil {
+			return fmt.Errorf("failed to download binary: %w", err)
+		}
+		defer os.Remove(tempFile)
+
+		fmt.Println("Verifying downloaded binary...")
+		if err := verifyBinary(tempFile); err != nil {
+			return fmt.Errorf("binary verification failed: %w", err)
+		}
+
+		fmt.Printf("Replacing binary at %s...\n", actualPath)
+		if err := replaceBinary(tempFile, actualPath); err != nil {
+			if os.IsPermission(err) || strings.Contains(err.Error(), "permission denied") {
+				return fmt.Errorf("permission denied: unable to write to %s\n"+
+					"Tip: You may need to run with sudo if the binary is in a system directory:\n"+
+					"   sudo %s update", actualPath, execPath)
+			}
+			return fmt.Errorf("failed to replace binary: %w", err)
+		}
+
+		fmt.Println("✅ Verifying installation...")
+		if err := verifyInstallation(actualPath); err != nil {
+			return fmt.Errorf("installation verification failed: %w", err)
+		}
+
+		fmt.Printf("\n✅ Successfully updated to %s!\n", latestVersion)
+		fmt.Printf("   Location: %s\n", actualPath)
+		return nil
+	},
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&forceUpdate, "force", false, "Force update even if already on latest version")
+	rootCmd.AddCommand(updateCmd)
+}
+
+func fetchLatestRelease() (*GitHubRelease, error) {
+	url := "https://api.github.com/repos/getoptimum/mump2p-cli/releases/latest"
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "mump2p-cli-updater")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch release info: %w\n"+
+			"Tip: Check your internet connection and try again", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status %d. Please try again later", resp.StatusCode)
+	}
+
+	var release GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to parse release info: %w", err)
+	}
+
+	if release.TagName == "" {
+		return nil, fmt.Errorf("no tag name found in release")
+	}
+
+	return &release, nil
+}
+
+func getBinaryNameForOS() (string, error) {
+	osName := runtime.GOOS
+	switch osName {
+	case "linux":
+		return "mump2p-linux", nil
+	case "darwin":
+		return "mump2p-mac", nil
+	default:
+		return "", fmt.Errorf("unsupported OS: %s. Supported: Linux, macOS", osName)
+	}
+}
+
+func downloadBinary(url string) (string, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Minute,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create download request: %w", err)
+	}
+	
+	req.Header.Set("User-Agent", "mump2p-cli-updater")
+	
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to download binary: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	tempFile, err := os.CreateTemp("", "mump2p-update-*")
+	if err != nil {
+		return "", err
+	}
+	defer tempFile.Close()
+
+	_, err = io.Copy(tempFile, resp.Body)
+	if err != nil {
+		os.Remove(tempFile.Name())
+		return "", err
+	}
+
+	if err := os.Chmod(tempFile.Name(), 0755); err != nil {
+		os.Remove(tempFile.Name())
+		return "", err
+	}
+
+	return tempFile.Name(), nil
+}
+
+func verifyBinary(binaryPath string) error {
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		return err
+	}
+
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("downloaded file is not executable")
+	}
+
+	cmd := exec.Command(binaryPath, "version")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("binary verification failed: %w", err)
+	}
+
+	return nil
+}
+
+func replaceBinary(tempFile, targetPath string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("Windows is not supported")
+	}
+
+	targetDir := filepath.Dir(targetPath)
+	if info, err := os.Stat(targetDir); err == nil {
+		if info.Mode().Perm()&0200 == 0 {
+			return fmt.Errorf("permission denied: directory %s is not writable", targetDir)
+		}
+	}
+
+	backupPath := targetPath + ".backup"
+	if err := copyFile(targetPath, backupPath); err != nil {
+		_ = os.Remove(backupPath)
+	}
+
+	if err := os.Remove(targetPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove old binary: %w", err)
+		}
+	}
+
+	if err := copyFile(tempFile, targetPath); err != nil {
+		if backupPath != "" {
+			if _, err := os.Stat(backupPath); err == nil {
+				_ = copyFile(backupPath, targetPath)
+			}
+		}
+		return fmt.Errorf("failed to install new binary: %w", err)
+	}
+
+	if err := os.Chmod(targetPath, 0755); err != nil {
+		return fmt.Errorf("failed to set executable permissions: %w", err)
+	}
+
+	if backupPath != "" {
+		_ = os.Remove(backupPath)
+	}
+
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	return err
+}
+
+func verifyInstallation(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to run version command: %w", err)
+	}
+
+	if !strings.Contains(string(output), "Version:") {
+		return fmt.Errorf("unexpected version output: %s", string(output))
+	}
+
+	return nil
+}
+
+func getAssetNames(assets []struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}) []string {
+	names := make([]string, len(assets))
+	for i, asset := range assets {
+		names[i] = asset.Name
+	}
+	return names
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+var suffixRegexp = regexp.MustCompile(`^([a-zA-Z]+)(\d+)$`)
+
 // Compare compares two version strings
 // Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
 // Handles semantic versions like v0.0.1-rc4
@@ -61,11 +63,8 @@ func Compare(v1, v2 string) int {
 // CompareSuffixes compares version suffixes like "rc10", "rc11", "beta1", etc.
 // It handles numeric suffixes properly so rc10 < rc11 (not rc10 < rc2)
 func CompareSuffixes(s1, s2 string) int {
-	// Extract numeric parts from suffixes (e.g., "rc10" -> "rc" and 10)
-	re := regexp.MustCompile(`^([a-zA-Z]+)(\d+)$`)
-
-	match1 := re.FindStringSubmatch(s1)
-	match2 := re.FindStringSubmatch(s2)
+	match1 := suffixRegexp.FindStringSubmatch(s1)
+	match2 := suffixRegexp.FindStringSubmatch(s2)
 
 	// If both match the pattern (e.g., "rc10"), compare numerically
 	if len(match1) == 3 && len(match2) == 3 {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,124 @@
+package version
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Compare compares two version strings
+// Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
+// Handles semantic versions like v0.0.1-rc4
+func Compare(v1, v2 string) int {
+	// Remove 'v' prefix if present
+	v1 = strings.TrimPrefix(v1, "v")
+	v2 = strings.TrimPrefix(v2, "v")
+
+	// If versions are identical, return 0
+	if v1 == v2 {
+		return 0
+	}
+
+	// Split versions into base and suffix (e.g., "0.0.1-rc4" -> ["0.0.1", "rc4"])
+	v1Parts := strings.SplitN(v1, "-", 2)
+	v2Parts := strings.SplitN(v2, "-", 2)
+
+	v1Base := v1Parts[0]
+	v2Base := v2Parts[0]
+
+	// Compare base versions (e.g., "0.0.1")
+	if v1Base != v2Base {
+		// Simple string comparison for base versions
+		// This works for most cases, but could be improved with proper semver parsing
+		if v1Base < v2Base {
+			return -1
+		}
+		return 1
+	}
+
+	// If base versions are the same, compare suffixes (e.g., "rc4" vs "rc5")
+	v1Suffix := ""
+	v2Suffix := ""
+	if len(v1Parts) > 1 {
+		v1Suffix = v1Parts[1]
+	}
+	if len(v2Parts) > 1 {
+		v2Suffix = v2Parts[1]
+	}
+
+	// If one has a suffix and the other doesn't, the one without suffix is newer (e.g., "0.0.1" > "0.0.1-rc5")
+	if v1Suffix == "" && v2Suffix != "" {
+		return 1
+	}
+	if v1Suffix != "" && v2Suffix == "" {
+		return -1
+	}
+
+	// Compare suffixes - handle numeric suffixes properly (e.g., rc10 vs rc11)
+	return CompareSuffixes(v1Suffix, v2Suffix)
+}
+
+// CompareSuffixes compares version suffixes like "rc10", "rc11", "beta1", etc.
+// It handles numeric suffixes properly so rc10 < rc11 (not rc10 < rc2)
+func CompareSuffixes(s1, s2 string) int {
+	// Extract numeric parts from suffixes (e.g., "rc10" -> "rc" and 10)
+	re := regexp.MustCompile(`^([a-zA-Z]+)(\d+)$`)
+
+	match1 := re.FindStringSubmatch(s1)
+	match2 := re.FindStringSubmatch(s2)
+
+	// If both match the pattern (e.g., "rc10"), compare numerically
+	if len(match1) == 3 && len(match2) == 3 {
+		prefix1, numStr1 := match1[1], match1[2]
+		prefix2, numStr2 := match2[1], match2[2]
+
+		// If prefixes match (e.g., both "rc"), compare numbers
+		if prefix1 == prefix2 {
+			num1, err1 := strconv.Atoi(numStr1)
+			num2, err2 := strconv.Atoi(numStr2)
+
+			if err1 == nil && err2 == nil {
+				if num1 < num2 {
+					return -1
+				}
+				if num1 > num2 {
+					return 1
+				}
+				return 0
+			}
+		}
+
+		// If prefixes don't match, compare prefixes first
+		if prefix1 != prefix2 {
+			if prefix1 < prefix2 {
+				return -1
+			}
+			if prefix1 > prefix2 {
+				return 1
+			}
+		}
+
+		// If prefixes match but we couldn't parse numbers, fall back to numeric comparison
+		num1, err1 := strconv.Atoi(numStr1)
+		num2, err2 := strconv.Atoi(numStr2)
+
+		if err1 == nil && err2 == nil {
+			if num1 < num2 {
+				return -1
+			}
+			if num1 > num2 {
+				return 1
+			}
+			return 0
+		}
+	}
+
+	// Fall back to string comparison for non-standard formats
+	if s1 < s2 {
+		return -1
+	}
+	if s1 > s2 {
+		return 1
+	}
+	return 0
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,10 @@
-package version
+package version_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/getoptimum/mump2p-cli/internal/version"
+)
 
 func TestCompare(t *testing.T) {
 	tests := []struct {
@@ -25,7 +29,7 @@ func TestCompare(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := Compare(tt.v1, tt.v2)
+			result := version.Compare(tt.v1, tt.v2)
 			if result != tt.expected {
 				t.Errorf("Compare(%q, %q) = %d, want %d", tt.v1, tt.v2, result, tt.expected)
 			}
@@ -53,7 +57,7 @@ func TestCompareSuffixes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CompareSuffixes(tt.s1, tt.s2)
+			result := version.CompareSuffixes(tt.s1, tt.s2)
 			if result != tt.expected {
 				t.Errorf("CompareSuffixes(%q, %q) = %d, want %d", tt.s1, tt.s2, result, tt.expected)
 			}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,62 @@
+package version
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int // -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
+	}{
+		{"same version", "v0.0.1-rc8", "v0.0.1-rc8", 0},
+		{"rc8 < rc9", "v0.0.1-rc8", "v0.0.1-rc9", -1},
+		{"rc9 > rc8", "v0.0.1-rc9", "v0.0.1-rc8", 1},
+		{"rc9 < rc10", "v0.0.1-rc9", "v0.0.1-rc10", -1},
+		{"rc10 > rc9", "v0.0.1-rc10", "v0.0.1-rc9", 1},
+		{"rc10 < rc11", "v0.0.1-rc10", "v0.0.1-rc11", -1},
+		{"rc11 > rc10", "v0.0.1-rc11", "v0.0.1-rc10", 1},
+		{"rc2 < rc10", "v0.0.1-rc2", "v0.0.1-rc10", -1},
+		{"rc10 > rc2", "v0.0.1-rc10", "v0.0.1-rc2", 1},
+		{"release > rc", "v0.0.1", "v0.0.1-rc10", 1},
+		{"rc < release", "v0.0.1-rc10", "v0.0.1", -1},
+		{"different base", "v0.0.1-rc8", "v0.0.2-rc1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Compare(tt.v1, tt.v2)
+			if result != tt.expected {
+				t.Errorf("Compare(%q, %q) = %d, want %d", tt.v1, tt.v2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompareSuffixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		s1       string
+		s2       string
+		expected int
+	}{
+		{"rc10 < rc11", "rc10", "rc11", -1},
+		{"rc11 > rc10", "rc11", "rc10", 1},
+		{"rc2 < rc10", "rc2", "rc10", -1},
+		{"rc10 > rc2", "rc10", "rc2", 1},
+		{"rc9 < rc10", "rc9", "rc10", -1},
+		{"rc10 > rc9", "rc10", "rc9", 1},
+		{"same suffix", "rc10", "rc10", 0},
+		{"beta1 < beta10", "beta1", "beta10", -1},
+		{"beta10 > beta1", "beta10", "beta1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CompareSuffixes(tt.s1, tt.s2)
+			if result != tt.expected {
+				t.Errorf("CompareSuffixes(%q, %q) = %d, want %d", tt.s1, tt.s2, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```

swarnabhasinha@Swarnabhas-MacBook-Pro mump2p-cli % ./mump2p-cli update                                                    
Checking for updates...
Current version: unknown
Latest version: v0.0.1-rc8
Updating from unknown to v0.0.1-rc8...
Downloading mump2p-mac...
Verifying downloaded binary...
Replacing binary at /Users/swarnabhasinha/mump2p-cli/mump2p-cli...
✅ Verifying installation...

✅ Successfully updated to v0.0.1-rc8!
   Location: /Users/swarnabhasinha/mump2p-cli/mump2p-cli
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic CLI update command that checks GitHub, downloads, verifies, and installs newer releases with automatic backup of the previous binary.
  * Added a --force option to bypass version checks.
  * Improved version comparison to better determine newer/older releases (including pre-release suffixes).

* **Tests**
  * Added unit tests validating version comparison logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->