### PR TITLE
fix: add HTTP client timeouts and improve error handling in publish/subscribe/list

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -54,7 +54,7 @@ This command shows your active topics and their count.`,
 			req.Header.Set("Content-Type", "application/json")
 
 			// Execute the request
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := httpClient.Do(req)
 			if err != nil {
 				return fmt.Errorf("HTTP GET request failed: %v", err)
 			}
@@ -146,7 +146,7 @@ This command shows your active topics and their count.`,
 		req.Header.Set("Content-Type", "application/json")
 
 		// Execute the request
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return fmt.Errorf("HTTP GET request failed: %v", err)
 		}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -206,9 +207,9 @@ var publishCmd = &cobra.Command{
 			}
 
 			url := baseURL + "/api/v1/publish"
-			req, err := http.NewRequest("POST", url, strings.NewReader(string(reqBytes)))
+			req, err := http.NewRequest("POST", url, bytes.NewReader(reqBytes))
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create publish request: %v", err)
 			}
 			// Only set Authorization header if auth is enabled
 			if !IsAuthDisabled() && token != nil {
@@ -216,12 +217,15 @@ var publishCmd = &cobra.Command{
 			}
 			req.Header.Set("Content-Type", "application/json")
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := httpClient.Do(req)
 			if err != nil {
 				return fmt.Errorf("HTTP publish failed: %v", err)
 			}
 			defer resp.Body.Close() //nolint:errcheck
-			body, _ := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read publish response: %v", err)
+			}
 			if resp.StatusCode != 200 {
 				return fmt.Errorf("publish error: %s", string(body))
 			}

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -226,13 +226,16 @@ var subscribeCmd = &cobra.Command{
 			}
 			req.Header.Set("Content-Type", "application/json")
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := httpClient.Do(req)
 			if err != nil {
 				return fmt.Errorf("HTTP POST subscribe failed: %v", err)
 			}
 
 			defer resp.Body.Close() //nolint:errcheck
-			body, _ := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to read subscribe response: %v", err)
+			}
 
 			if resp.StatusCode != 200 {
 				return fmt.Errorf("HTTP POST subscribe error: %s", string(body))
@@ -291,7 +294,7 @@ var subscribeCmd = &cobra.Command{
 							return
 						}
 						req.Header.Set("Content-Type", "application/json")
-						resp, err := http.DefaultClient.Do(req)
+						resp, err := httpClient.Do(req)
 						if err != nil {
 							fmt.Printf("Webhook request error: %v\n", err)
 							return
@@ -404,7 +407,7 @@ var subscribeCmd = &cobra.Command{
 					}
 					req.Header.Set("Content-Type", "application/json")
 
-					resp, err := http.DefaultClient.Do(req)
+					resp, err := httpClient.Do(req)
 					if err != nil {
 						fmt.Printf("Webhook request error: %v\n", err)
 						return

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"net/http"
 	"regexp"
+	"time"
 )
+
+// httpClient is a shared HTTP client with a sensible timeout.
+// Use this instead of http.DefaultClient to prevent indefinite hangs
+// when the remote server is unreachable or slow to respond.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 // extractIPFromURL extracts IP address from URL string
 func extractIPFromURL(url string) string {


### PR DESCRIPTION
## Summary

- **Replace `http.DefaultClient`** (zero timeout) with a shared `httpClient` configured with a 30-second timeout in `publish`, `subscribe`, and `list-topics` commands. This prevents the CLI from hanging indefinitely when the remote server is unreachable or slow to respond.
- **Eliminate unnecessary allocation** in the HTTP publish path by using `bytes.NewReader` instead of `strings.NewReader(string(...))`, avoiding a redundant heap copy of the request payload.
- **Fix bare error return** in `publish.go` — the only `return err` without context wrapping in the entire function — to provide a descriptive message consistent with all other error returns.
- **Handle `io.ReadAll` errors** in `publish` and `subscribe` instead of silently discarding them with `_ =`, which previously produced empty error messages when the response body couldn't be read.

## Motivation

Several commands (`health`, `tracer`, `update`) already use properly configured HTTP clients with explicit timeouts. The `publish`, `subscribe`, and `list-topics` commands were the only ones still using `http.DefaultClient`, which has no timeout on any stage (DNS, TLS, response headers, body). This is an internal inconsistency and a real operational issue — a user running `mump2p publish` against a misconfigured or unreachable server would have their terminal freeze with no recovery.

The error handling fixes are in the same code paths and follow patterns already established elsewhere in the codebase (`list.go:64`, `health.go:54`).

## Changes

| File | Change |
|------|--------|
| `cmd/utils.go` | Add shared `httpClient` with 30s timeout |
| `cmd/publish.go` | Replace `DefaultClient`, use `bytes.NewReader`, wrap error, check `io.ReadAll` |
| `cmd/subscribe.go` | Replace `DefaultClient` (4 sites), check `io.ReadAll` |
| `cmd/list.go` | Replace `DefaultClient` (2 sites) |

## Test plan

- [x] `go build ./...` — compiles without errors
- [x] `go vet ./...` — no static analysis warnings
- [x] `go test ./...` — all unit tests pass
- [ ] Manual: `mump2p publish --topic=test --message=hello` against unreachable server now times out after 30s instead of hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request reliability by implementing request timeouts to prevent indefinite hangs.
  * Enhanced error messages for failed operations, providing clearer feedback when requests fail.

* **Chores**
  * Refactored HTTP client usage across commands for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->